### PR TITLE
resume_btn style

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -311,7 +311,7 @@ section {
 
   display: flex;
   justify-content: center;
-
+  align-items: center;
 
   background-color: #06283D;
   color: #BDCDD6;


### PR DESCRIPTION
resume_btn @media 400px. the text inside the button it was coming out of the area. I add in the resume_btn selector ` align-items: center;` and tat solved the issue. now it will adjust to the size of the screen without problem and not need to add `@media`.   