### PR TITLE
contact section size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -38,6 +38,17 @@ body {
   padding: 4rem 6rem;
 }
 
+@media screen and (max-width: 550px) {
+  .section__padding {
+    padding: 2rem;
+  }
+}
+@media screen and (max-width: 400px) {
+  .section__padding {
+    padding: 2rem 1rem;
+  }
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
the style of the contact boxes from 550px screen started  to become square and ugly because  the padding of the section. I add to `.section__padding` two @media for 550px and 400px to change the padding rules. 